### PR TITLE
Do not require CUDA in CPU-only environments

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -144,7 +144,7 @@ INTERFACE
 
 target_compile_features(
   rapids_triton INTERFACE cxx_std_17
-  $<BUILD_INTERFACE:cuda_std_17>
+  $<$<AND:BUILD_INTERFACE,$<BOOL:TRITON_ENABLE_GPU>>:cuda_std_17>
 )
 
 rapids_cmake_install_lib_dir(lib_dir)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -145,7 +145,7 @@ INTERFACE
 if (TRITON_ENABLE_GPU)
   target_compile_features(
     rapids_triton INTERFACE cxx_std_17
-    $<BUILD_INTERFACE>:cuda_std_17>
+    $<BUILD_INTERFACE:cuda_std_17>
   )
 else()
   target_compile_features(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -142,10 +142,16 @@ INTERFACE
   triton-backend-utils
 )
 
-target_compile_features(
-  rapids_triton INTERFACE cxx_std_17
-  $<$<AND:$<BOOL:BUILD_INTERFACE>,$<BOOL:TRITON_ENABLE_GPU>>:cuda_std_17>
-)
+if (TRITON_ENABLE_GPU)
+  target_compile_features(
+    rapids_triton INTERFACE cxx_std_17
+    $<BUILD_INTERFACE>:cuda_std_17>
+  )
+else()
+  target_compile_features(
+    rapids_triton INTERFACE cxx_std_17
+  )
+endif()
 
 rapids_cmake_install_lib_dir(lib_dir)
 install(TARGETS rapids_triton

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -59,9 +59,11 @@ message(VERBOSE "RAPIDS_TRITON: Triton backend repo tag: ${TRITON_BACKEND_REPO_T
 
 if(TRITON_ENABLE_GPU)
   rapids_cuda_init_architectures(RAPIDS_TRITON)
+  project(RAPIDS_TRITON VERSION 21.10.00 LANGUAGES CXX CUDA)
+else()
+  project(RAPIDS_TRITON VERSION 21.10.00 LANGUAGES CXX)
 endif()
 
-project(RAPIDS_TRITON VERSION 21.10.00 LANGUAGES CXX CUDA)
 
 ##############################################################################
 # - build type ---------------------------------------------------------------
@@ -92,17 +94,19 @@ endif()
 # - compiler options ---------------------------------------------------------
 set(CMAKE_C_COMPILER_LAUNCHER ccache)
 set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
-set(CMAKE_CUDA_COMPILER_LAUNCHER ccache)
+if(TRITON_ENABLE_GPU)
+  set(CMAKE_CUDA_COMPILER_LAUNCHER ccache)
 
-# * find CUDAToolkit package
-# * determine GPU architectures
-# * enable the CMake CUDA language
-# * set other CUDA compilation flags
-rapids_find_package(CUDAToolkit REQUIRED
-    BUILD_EXPORT_SET rapids_triton-exports
-    INSTALL_EXPORT_SET rapids_triton-exports
-    )
-include(cmake/modules/ConfigureCUDA.cmake)
+  # * find CUDAToolkit package
+  # * determine GPU architectures
+  # * enable the CMake CUDA language
+  # * set other CUDA compilation flags
+  rapids_find_package(CUDAToolkit REQUIRED
+      BUILD_EXPORT_SET rapids_triton-exports
+      INSTALL_EXPORT_SET rapids_triton-exports
+      )
+  include(cmake/modules/ConfigureCUDA.cmake)
+endif()
 
 ##############################################################################
 # - Requirements -------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -144,7 +144,7 @@ INTERFACE
 
 target_compile_features(
   rapids_triton INTERFACE cxx_std_17
-  $<$<AND:BUILD_INTERFACE,$<BOOL:TRITON_ENABLE_GPU>>:cuda_std_17>
+  $<$<AND:$<BOOL:BUILD_INTERFACE>,$<BOOL:TRITON_ENABLE_GPU>>:cuda_std_17>
 )
 
 rapids_cmake_install_lib_dir(lib_dir)

--- a/python/rapids_triton/triton/io.py
+++ b/python/rapids_triton/triton/io.py
@@ -17,11 +17,12 @@ from uuid import uuid4
 
 import tritonclient.http as triton_http
 import tritonclient.grpc as triton_grpc
+from rapids_triton.utils.safe_import import ImportReplacement
+from tritonclient import utils as triton_utils
 try:
     import tritonclient.utils.cuda_shared_memory as shm
 except OSError:  # CUDA libraries not available
-    shm = None
-from tritonclient import utils as triton_utils
+    shm = ImportReplacement('tritonclient.utils.cuda_shared_memory')
 
 
 TritonInput = namedtuple('TritonInput', ('name', 'input'))

--- a/python/rapids_triton/triton/io.py
+++ b/python/rapids_triton/triton/io.py
@@ -17,7 +17,10 @@ from uuid import uuid4
 
 import tritonclient.http as triton_http
 import tritonclient.grpc as triton_grpc
-import tritonclient.utils.cuda_shared_memory as shm
+try:
+    import tritonclient.utils.cuda_shared_memory as shm
+except OSError:  # CUDA libraries not available
+    shm = None
 from tritonclient import utils as triton_utils
 
 

--- a/python/rapids_triton/triton/response.py
+++ b/python/rapids_triton/triton/response.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tritonclient.utils.cuda_shared_memory as shm
-except OSError:
-    shm = None
 from tritonclient import utils as triton_utils
 
 from rapids_triton.triton.message import TritonMessage
+from rapids_triton.utils.safe_import import ImportReplacement
+try:
+    import tritonclient.utils.cuda_shared_memory as shm
+except OSError:  # CUDA libraries not available
+    shm = ImportReplacement('tritonclient.utils.cuda_shared_memory')
 
 
 def get_response_data(response, output_handle, output_name):

--- a/python/rapids_triton/triton/response.py
+++ b/python/rapids_triton/triton/response.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tritonclient.utils.cuda_shared_memory as shm
+try:
+    import tritonclient.utils.cuda_shared_memory as shm
+except OSError:
+    shm = None
 from tritonclient import utils as triton_utils
 
 from rapids_triton.triton.message import TritonMessage

--- a/python/rapids_triton/utils/safe_import.py
+++ b/python/rapids_triton/utils/safe_import.py
@@ -1,0 +1,22 @@
+class UnavailableError(Exception):
+    '''Error thrown if a symbol is unavailable due to an issue importing it'''
+
+class ImportReplacement:
+    """A class to be used in place of an importable symbol if that symbol
+    cannot be imported
+
+    Parameters
+    ----------
+    symbol: str
+        The name or import path to be used in error messages when attempting to
+        make use of this symbol. E.g. "some_pkg.func" would result in an
+        exception with message "some_pkg.func could not be imported"
+    """
+    def __init__(self, symbol):
+        self._msg = f'{symbol} could not be imported'
+
+    def __getattr__(self, name):
+        raise UnavailableError(self._msg)
+
+    def __call__(self, *args, **kwargs):
+        raise UnavailableError(self._msg)


### PR DESCRIPTION
Prior to this PR, some sections of CMakeLists.txt would require that nvcc be present in the environment. Furthermore, importing `cuda_shared_memory` from the `tritonclient` package would fail if CUDA were not available. CMakeLists.txt has been updated, and `cuda_shared_memory` imports have been appropriately guarded.