### PR TITLE
Get and Check Output Names

### DIFF
--- a/cpp/include/rapids_triton/model/shared_state.hpp
+++ b/cpp/include/rapids_triton/model/shared_state.hpp
@@ -110,7 +110,7 @@ struct SharedModelState {
       std::begin(output_shapes_), std::end(output_shapes_), name, [](auto& entry, auto& value) {
         return entry.first < value;
       });
-    if (cached_shape == std::end(output_shapes_)) {
+    if (cached_shape == std::end(output_shapes_) || name != cached_shape->first) {
       auto log_stream = std::stringstream{};
       log_stream << "No output with name " << name << " in configuration.";
       throw TritonException(Error::Internal, log_stream.str());

--- a/cpp/include/rapids_triton/model/shared_state.hpp
+++ b/cpp/include/rapids_triton/model/shared_state.hpp
@@ -128,7 +128,8 @@ struct SharedModelState {
     return output_names;
   }
 
-  auto check_output_name(std::string const& name) const -> bool {
+  auto check_output_name(std::string const& name) const {
+    // #TODO: Figure out a way to use std::binary_search here
     auto cached_shape = std::lower_bound(
       std::begin(output_shapes_), std::end(output_shapes_), name, [](auto& entry, auto& value) {
         return entry.first < value;

--- a/cpp/include/rapids_triton/model/shared_state.hpp
+++ b/cpp/include/rapids_triton/model/shared_state.hpp
@@ -129,10 +129,11 @@ struct SharedModelState {
   }
 
   auto check_output_name(std::string const& name) const -> bool {
-    return std::binary_search(
+    auto cached_shape = std::lower_bound(
       std::begin(output_shapes_), std::end(output_shapes_), name, [](auto& entry, auto& value) {
         return entry.first < value;
       });
+    return cached_shape != std::end(output_shapes_) && name == cached_shape->first;
   }
 
  private:

--- a/cpp/include/rapids_triton/model/shared_state.hpp
+++ b/cpp/include/rapids_triton/model/shared_state.hpp
@@ -119,6 +119,22 @@ struct SharedModelState {
     }
   }
 
+  auto get_output_names() const {
+    auto output_names = std::vector<std::string>{output_shapes_.size()};
+    std::for_each(std::begin(output_shapes_), std::end(output_shapes_), [&output_names](auto& output_shape) {
+      output_names.push_back(output_shape.first);
+    });
+    return output_names;
+  }
+
+  auto check_output_name(std::string const& name) const -> bool {
+    auto cached_shape = std::lower_bound(
+      std::begin(output_shapes_), std::end(output_shapes_), name, [](auto& entry, auto& value) {
+        return entry.first < value;
+      });
+    return cached_shape != std::end(output_shapes_);
+  }
+
  private:
   std::unique_ptr<common::TritonJson::Value> config_;
   Batch::size_type max_batch_size_;


### PR DESCRIPTION
Enhancements to `SharedState` object to provide all output names, as well as to check if a named output exists