### PR TITLE
Update testing environment and tweak tests for Triton 22.08

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=21.12
+ARG TRITON_VERSION=22.08
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to build indicated components

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -9,9 +9,9 @@ EXAMPLE_TAG=rapids_triton_identity \
   $REPODIR/build.sh
 if [ -z $CUDA_VISIBLE_DEVICES ]
 then
-  docker run --gpus all --rm rapids_triton_identity_test
+  docker run -v "${REPODIR}/qa/logs:/qa/logs" --gpus all --rm rapids_triton_identity_test
 else
-  docker run --gpus $CUDA_VISIBLE_DEVICES --rm rapids_triton_identity_test
+  docker run -v "${REPODIR}/qa/logs:/qa/logs" --gpus $CUDA_VISIBLE_DEVICES --rm rapids_triton_identity_test
 fi
 EXAMPLE_TAG=rapids_triton_identity:cpu \
   TEST_TAG=rapids_triton_identity_test:cpu \

--- a/conda/environments/rapids_triton_dev.yml
+++ b/conda/environments/rapids_triton_dev.yml
@@ -4,6 +4,8 @@ channels:
   - conda-forge
 dependencies:
   - ccache
-  - cmake>=3.21
+  - cmake>=3.23.1
+  - libstdcxx-ng<=11.2.0
+  - libgcc-ng<=11.2.0
   - ninja
   - rapidjson

--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -97,6 +97,7 @@ finally() {
     docker rm -f $CONTAINER_NAME > /dev/null 2>&1
   else
     kill -15 $TRITON_PID
+    wait
   fi
 }
 


### PR DESCRIPTION
Update default base image to latest released Triton image.
Update conda dependency pinning.
Tweak testing scripts to correctly handle latest Triton image.
Tweak testing scripts to correctly handle CUDA_VISIBLE_DEVICES.