### PR TITLE
Remove deprecated supports_streams method from memory resource

### DIFF
--- a/cpp/include/rapids_triton/triton/triton_memory_resource.hpp
+++ b/cpp/include/rapids_triton/triton/triton_memory_resource.hpp
@@ -38,7 +38,6 @@ struct triton_memory_resource final : public rmm::mr::device_memory_resource {
   {
   }
 
-  bool supports_streams() const noexcept override { return false; }
   auto* get_triton_manager() const noexcept { return manager_; }
 
  private:


### PR DESCRIPTION
Remove supports_streams method from resource for compatibility with https://github.com/rapidsai/rmm/pull/1519