### PR TITLE
Update RMM includes from `<rmm/mr/device/*>` to `<rmm/mr/*>`

### DIFF
--- a/cpp/include/rapids_triton/memory/detail/gpu_only/resource.hpp
+++ b/cpp/include/rapids_triton/memory/detail/gpu_only/resource.hpp
@@ -24,8 +24,8 @@
 #include <rapids_triton/triton/device.hpp>
 #include <rapids_triton/triton/triton_memory_resource.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 
 namespace triton {
 namespace backend {

--- a/cpp/include/rapids_triton/triton/triton_memory_resource.hpp
+++ b/cpp/include/rapids_triton/triton/triton_memory_resource.hpp
@@ -23,7 +23,7 @@
 #include <rapids_triton/exceptions.hpp>
 #include <rapids_triton/triton/device.hpp>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 #include <stdexcept>
 #include <utility>
 

--- a/cpp/test/memory/resource.cpp
+++ b/cpp/test/memory/resource.cpp
@@ -17,8 +17,8 @@
 #ifdef TRITON_ENABLE_GPU
 #include <cuda_runtime_api.h>
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 #endif
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
This updates RMM memory resource includes to use the header path `<rmm/mr/*>` instead of `<rmm/mr/device/*>`.

xref: https://github.com/rapidsai/rmm/issues/2141
