### PR TITLE
Prevent integer overflow when computing buffer size

### DIFF
--- a/cpp/include/rapids_triton/batch/batch.hpp
+++ b/cpp/include/rapids_triton/batch/batch.hpp
@@ -42,6 +42,7 @@
 #include <rapids_triton/triton/responses.hpp>
 #include <rapids_triton/triton/statistics.hpp>
 #include <rapids_triton/utils/narrow.hpp>
+#include <rapids_triton/utils/safe_multiply.hpp>
 #include <string>
 #include <vector>
 
@@ -133,7 +134,8 @@ struct Batch {
   {
     auto shape = get_input_shape<T>(name);
     auto size_bytes =
-      sizeof(T) * std::reduce(shape.begin(), shape.end(), std::size_t{1}, std::multiplies<>());
+      safe_multiply<std::size_t>(
+          sizeof(T), std::reduce(shape.begin(), shape.end(), std::size_t{1}, safe_multiply<std::size_t>));
     auto allowed_memory_configs = std::vector<std::pair<MemoryType, int64_t>>{};
     if (memory_type.has_value()) {
       allowed_memory_configs.emplace_back(memory_type.value(), device_id);
@@ -206,7 +208,7 @@ struct Batch {
                             "At least one input must be retrieved before any output");
     }
     auto shape       = get_output_shape_(name, batch_size_.value());
-    auto buffer_size = std::reduce(shape.begin(), shape.end(), std::size_t{1}, std::multiplies<>());
+    auto buffer_size = std::reduce(shape.begin(), shape.end(), std::size_t{1}, safe_multiply<std::size_t>);
     auto final_memory_type = MemoryType{};
     if (memory_type.has_value()) {
       final_memory_type = memory_type.value();

--- a/cpp/include/rapids_triton/memory/detail/gpu_only/owned_device_buffer.hpp
+++ b/cpp/include/rapids_triton/memory/detail/gpu_only/owned_device_buffer.hpp
@@ -19,6 +19,7 @@
 #include <rapids_triton/memory/detail/owned_device_buffer.hpp>
 #include <rapids_triton/triton/device.hpp>
 #include <rapids_triton/utils/device_setter.hpp>
+#include <rapids_triton/utils/safe_multiply.hpp>
 #include <rmm/device_buffer.hpp>
 
 namespace triton {
@@ -32,7 +33,9 @@ struct owned_device_buffer<T, true> {
   owned_device_buffer(device_id_t device_id, std::size_t size, cudaStream_t stream)
     : data_{[&device_id, &size, &stream]() {
       auto device_context = device_setter{device_id};
-      return rmm::device_buffer{size * sizeof(T), rmm::cuda_stream_view{stream}};
+      return rmm::device_buffer{
+        safe_multiply<std::size_t>(size, sizeof(T)),
+        rmm::cuda_stream_view{stream}};
     }()}
   {
   }

--- a/cpp/include/rapids_triton/utils/safe_multiply.hpp
+++ b/cpp/include/rapids_triton/utils/safe_multiply.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <rapids_triton/exceptions.hpp>
+#include <type_traits>
+
+namespace triton {
+namespace backend {
+namespace rapids {
+
+template <typename T>
+T safe_multiply(T a, T b) {
+  static_assert(std::is_unsigned_v<T> && std::is_integral_v<T>,
+                "safe_multiply only defined for unsigned integers");
+  T result = a * b;
+  if (a != 0 && result / a != b) {
+    throw TritonException(Error::Internal, "Overflow detected in multiply");
+  }
+  return result;
+}
+
+}  // namespace rapids
+}  // namespace backend
+}  // namespace triton


### PR DESCRIPTION
When computing the buffer size for input and output arrays, make sure that the product of shape dimensions does not exceed `SIZE_MAX`. 