### PR TITLE
Fix output buffer lifetime during asynchronous response copies

### DIFF
--- a/cpp/include/rapids_triton/batch/batch.hpp
+++ b/cpp/include/rapids_triton/batch/batch.hpp
@@ -90,6 +90,7 @@ struct Batch {
       get_output_shape_{std::move(get_output_shape)},
       report_statistics_{std::move(report_request_statistics)},
       collector_(raw_requests, count, &responses_, &triton_mem_manager, use_pinned_input, stream),
+      retained_output_buffers_{},
       responder_{std::make_shared<BackendOutputResponder>(raw_requests,
                                                           count,
                                                           &responses_,
@@ -217,8 +218,17 @@ struct Batch {
       // non-shared-memory responses.
       final_memory_type = HostMemory;
     }
-    auto buffer = Buffer<T>(buffer_size, final_memory_type, device_id, stream);
-    return OutputTensor<T>(std::move(shape), std::move(buffer), name, responder_);
+    // OutputTensor receives a non-owning view. Keep the allocation alive until
+    // this Batch is destroyed after response processing has completed.
+    auto retained_buffer =
+      std::make_shared<Buffer<T>>(buffer_size, final_memory_type, device_id, stream);
+    auto view = Buffer<T>(retained_buffer->data(),
+                          retained_buffer->size(),
+                          retained_buffer->mem_type(),
+                          retained_buffer->device(),
+                          retained_buffer->stream());
+    retained_output_buffers_.push_back(std::move(retained_buffer));
+    return OutputTensor<T>(std::move(shape), std::move(view), name, responder_);
   }
 
   template <typename T>
@@ -265,6 +275,9 @@ struct Batch {
                      time_point const&)>
     report_statistics_;
   BackendInputCollector collector_;
+  // Declared before responder_ so retained source buffers outlive it. The
+  // buffers are released when this Batch leaves execute().
+  std::vector<std::shared_ptr<void>> retained_output_buffers_;
   std::shared_ptr<BackendOutputResponder> responder_;
   cudaStream_t stream_;
   std::chrono::time_point<std::chrono::steady_clock> start_time_;

--- a/cpp/include/rapids_triton/tensor/tensor.hpp
+++ b/cpp/include/rapids_triton/tensor/tensor.hpp
@@ -137,6 +137,17 @@ struct OutputTensor final : BaseTensor<T> {
     : BaseTensor<T>(std::move(shape), std::move(buffer)), name_{name}, responder_{responder}
   {
   }
+
+  OutputTensor(OutputTensor const&) = delete;
+  OutputTensor(OutputTensor&& other)
+    : BaseTensor<T>(other.shape(), std::move(other.buffer())),
+      name_{std::move(other.name_)},
+      responder_{std::move(other.responder_)}
+  {
+  }
+  OutputTensor& operator=(OutputTensor const&) = delete;
+  OutputTensor& operator=(OutputTensor&&) = delete;
+
   /**
    * @brief Prepare final output data from this tensor for responding to
    * request

--- a/cpp/include/rapids_triton/triton/api/execute.hpp
+++ b/cpp/include/rapids_triton/triton/api/execute.hpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <rapids_triton/batch/batch.hpp>
 #include <rapids_triton/exceptions.hpp>
 #include <rapids_triton/triton/model.hpp>
@@ -100,6 +101,11 @@ auto* execute(TRITONBACKEND_ModelInstance* instance,
       model.predict(batch);
     } catch (TritonException& err) {
       predict_err = err.error();
+    } catch (std::exception const& err) {
+      predict_err = TRITONSERVER_ErrorNew(Error::Internal, err.what());
+    } catch (...) {
+      predict_err =
+        TRITONSERVER_ErrorNew(Error::Internal, "prediction failed with unknown exception");
     }
 
     auto& compute_start_time = batch.compute_start_time();
@@ -111,6 +117,10 @@ auto* execute(TRITONBACKEND_ModelInstance* instance,
       *instance, request_count, start_time, compute_start_time, compute_end_time, end_time);
   } catch (TritonException& err) {
     result = err.error();
+  } catch (std::exception const& err) {
+    result = TRITONSERVER_ErrorNew(Error::Internal, err.what());
+  } catch (...) {
+    result = TRITONSERVER_ErrorNew(Error::Internal, "execution failed with unknown exception");
   }
 
   return result;

--- a/cpp/test/tensor/tensor.cpp
+++ b/cpp/test/tensor/tensor.cpp
@@ -22,8 +22,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <rapids_triton/tensor/dtype.hpp>
 #include <rapids_triton/tensor/tensor.hpp>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace triton {
@@ -138,6 +141,40 @@ TEST(RapidsTriton, tensor_multi_copy)
   // Throw if trying to copy to too many outputs
   receivers.emplace_back(receiver_shape, Buffer<int>{std::size_t{1}, HostMemory});
   EXPECT_THROW(rapids::copy(receivers.begin(), receivers.end(), tensor1), TritonException);
+}
+
+TEST(RapidsTriton, retained_output_buffer_outlives_output_tensor)
+{
+  static_assert(!std::is_copy_constructible_v<OutputTensor<int>>);
+  static_assert(std::is_move_constructible_v<OutputTensor<int>>);
+
+  auto responses = std::vector<TRITONBACKEND_Response*>{};
+  auto responder = std::make_shared<BackendOutputResponder>(
+    nullptr, 0, &responses, 0, nullptr, false, cudaStream_t{});
+  auto expected        = std::vector<int>{1, 2, 3, 4};
+  auto retained_buffer = std::make_shared<Buffer<int>>(expected.size(), HostMemory);
+  auto* source_data    = retained_buffer->data();
+
+  {
+    auto view   = Buffer<int>(source_data,
+                            retained_buffer->size(),
+                            retained_buffer->mem_type(),
+                            retained_buffer->device(),
+                            retained_buffer->stream());
+    auto output = OutputTensor<int>(
+      std::vector<std::size_t>{expected.size()}, std::move(view), "output", responder);
+    std::copy(expected.begin(), expected.end(), source_data);
+    auto moved_output = std::move(output);
+    EXPECT_EQ(moved_output.data(), source_data);
+    moved_output.finalize();
+  }
+
+  EXPECT_EQ(retained_buffer->data(), source_data);
+  auto overwrite = Buffer<int>{expected.size(), HostMemory};
+  EXPECT_NE(overwrite.data(), source_data);
+  std::fill(overwrite.data(), overwrite.data() + overwrite.size(), -1);
+  EXPECT_THAT(std::vector<int>(source_data, source_data + expected.size()),
+              ::testing::ElementsAreArray(expected));
 }
 
 }  // namespace rapids

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -227,7 +227,10 @@ buffer can also be retrieved with the `buffer()` method.
 
 `OutputTensor` objects are used to store data which will eventually be returned
 as part of Triton's response to a client request. Their `finalize` methods are
-used to actually marshal their underlying data into a response.
+used to actually marshal their underlying data into a response. Output tensors
+returned by `get_output` are views into buffers retained by the owning batch
+until asynchronous response processing is complete. An output tensor must not
+be accessed after it has been finalized.
 
 In general, `OutputTensor` objects should not be constructed directly but
 should instead be retrieved using the `get_output` method of a `Model`


### PR DESCRIPTION
## Summary

Fixes #42, and thanks to @soohyeonlee-wq for originally reporting this issue and providing a reproduction.

I'm very new to here, so I may have been missed something or done things in a less-than-ideal way. I'd really appreciate any feedback or suggestions :)

`OutputTensor::finalize()` passes its buffer to `BackendOutputResponder`, which may continue using the buffer asynchronously. Previously, the owning `OutputTensor` could be destroyed when `predict()` returned, allowing the allocation to be reused before the response copy completed. This could overwrite inference outputs with data from subsequent requests.

This change:

- Retains owning output buffers in Batch until response processing completes.
- Returns non-owning OutputTensor views backed by those retained buffers.
- Makes OutputTensor non-copyable while preserving move construction.
- Converts unexpected prediction and execution exceptions into Triton internal errors.
- Documents the output tensor lifetime.
- Adds unit coverage for the retained backing allocation.

## Correctness testing

Reproduced the original issue with Triton 25.03 FIL under copy-engine pressure:

- 35 of 1,200 requests contained corrupted results.
- 25,088 output values were overwritten with million-range input values.

With the fix, a deterministic two-model stress test completed:

- 4,096 requests
- 0 invalid outputs
- All outputs exactly matched the expected value

The focused unit test also passes.

The complete local unit suite passed 28 of 29 tests. The remaining failure is the unchanged RapidsTriton.copy test in the local GPU/runtime environment.

## Performance

* Triton Inference Server: 26.05 / 25.03
* GPU: RTX 5060 8GB / nvidia graphic driver: 610.62
* protocol: gRPC
* 1-second warm-up, 5-second measurement

Five alternating trials at concurrency 16 showed no measurable regression:

```

   Batch size          Baseline             Fixed    Difference
  ━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━
            1    6,845.89 req/s    6,842.10 req/s       -0.055%
  ────────────  ────────────────  ────────────────  ────────────
        4,096      989.89 req/s      994.94 req/s        +0.51%
```

The differences are within normal run-to-run variation.

## Test

* Local test and docker build was passed.
* `Batch::get_output()` regression test was also passed.